### PR TITLE
Feature/refactor search result builder

### DIFF
--- a/lib/features/book_search/widgets/search_result_list/search_result_builder.dart
+++ b/lib/features/book_search/widgets/search_result_list/search_result_builder.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:material_floating_search_bar/material_floating_search_bar.dart';
 import 'package:provider/provider.dart';
 
 import 'package:reos_challenge/shared/providers/book_provider.dart';
@@ -11,57 +10,70 @@ import 'package:reos_challenge/features/book_search/widgets/search_result_list/s
 class SearchResultBuilder {
   static Widget buildList(
     BuildContext context,
-    FloatingSearchBarController searchbarController,
+    Function onResultselected,
   ) {
-    if (searchbarController.query.isNotEmpty) {
-      final List<Widget> bookResultList = context.read<BookProvider>().bookSearchResultList.map((book) {
-        return Column(
-          children: [
-            SearchResultListItem(
-              book: book,
-              onTab: () {
-                searchbarController.query = '';
-                searchbarController.close();
-                presentDetailScreen(context: context, book: book);
-              },
-            ),
-            Divider(color: Theme.of(context).dividerColor),
-          ],
-        );
-      }).toList();
+    final List<Widget> bookResultList = _buildBookResultList(context, onResultselected);
+    final List<Widget> authorResultList = _buildAuthorResultList(context, onResultselected);
 
-      final List<Widget> authorResultList = context.read<BookProvider>().authorSearchResultList.map((book) {
-        return Column(
-          children: [
-            SearchResultListItem(
-              book: book,
-              onTab: () {
-                searchbarController.query = '';
-                searchbarController.close();
-                presentDetailScreen(context: context, book: book);
-              },
-            ),
-            Divider(color: Theme.of(context).dividerColor),
-          ],
-        );
-      }).toList();
-
-      return Material(
-        color: Theme.of(context).colorScheme.background,
-        elevation: 2.0,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20.0),
-          child: Column(
-            key: const Key('searchResultDropdownList'),
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[if (bookResultList.isNotEmpty) const ListHeader(title: 'Books')] +
-                bookResultList +
-                [if (authorResultList.isNotEmpty) const ListHeader(title: 'Authors')] +
-                authorResultList,
-          ),
+    return Material(
+      key: const Key('searchResultKey'),
+      color: Theme.of(context).colorScheme.background,
+      elevation: 2.0,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20.0),
+        child: Column(
+          key: const Key('searchResultDropdownList'),
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[if (bookResultList.isNotEmpty) const ListHeader(title: 'Books')] +
+              bookResultList +
+              [if (authorResultList.isNotEmpty) const ListHeader(title: 'Authors')] +
+              authorResultList,
         ),
+      ),
+    );
+  }
+
+  static List<Widget> _buildBookResultList(
+    BuildContext context,
+    Function onResultTapped,
+  ) {
+    final List<Widget> bookResultList = context.read<BookProvider>().bookSearchResultList.map((book) {
+      return Column(
+        children: [
+          SearchResultListItem(
+            book: book,
+            onTab: () {
+              onResultTapped();
+              presentDetailScreen(context: context, book: book);
+            },
+          ),
+          Divider(color: Theme.of(context).dividerColor),
+        ],
       );
-    }
-    return const SizedBox();
+    }).toList();
+
+    return bookResultList;
+  }
+
+  static List<Widget> _buildAuthorResultList(
+    BuildContext context,
+    Function onResultTapped,
+  ) {
+    final List<Widget> authorResultList = context.read<BookProvider>().authorSearchResultList.map((book) {
+      return Column(
+        children: [
+          SearchResultListItem(
+            book: book,
+            onTab: () {
+              onResultTapped();
+              presentDetailScreen(context: context, book: book);
+            },
+          ),
+          Divider(color: Theme.of(context).dividerColor),
+        ],
+      );
+    }).toList();
+
+    return authorResultList;
   }
 }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -54,10 +54,16 @@ class _HomeScreenState extends State<HomeScreen> {
     _searchbarController.close();
   }
 
+  void onSearchResultTapped() {
+    _searchbarController.query = '';
+    _searchbarController.close();
+  }
+
   Widget buildSearchResulDropDownList(BuildContext context) {
+    if (_searchbarController.query.isEmpty) return const SizedBox();
     return SearchResultBuilder.buildList(
       context,
-      _searchbarController,
+      onSearchResultTapped,
     );
   }
 

--- a/test/features/book_search/widgets/search_result_list/search_result_builder_test.dart
+++ b/test/features/book_search/widgets/search_result_list/search_result_builder_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+import 'package:provider/provider.dart';
+import 'package:reos_challenge/features/book_search/widgets/search_result_list/search_result_list.dart';
+import 'package:reos_challenge/features/home/home_screen.dart';
+import 'package:reos_challenge/shared/models/book.dart';
+import 'package:reos_challenge/shared/providers/providers.dart';
+import 'package:reos_challenge/shared/repositories/repositories.dart';
+
+import '../../../../shared/providers/book_provider_test.mocks.dart';
+import '../../../../shared/providers/test_data.dart';
+
+final List<Book> expectedContinueBookList = [
+  TestData.algorithms,
+  TestData.structureAndInteroretationOfComputerPrograms,
+  TestData.codeComplete
+];
+final List<Book> expectedNewBookList = [TestData.cleanCode, TestData.cleanCoder, TestData.cleanArchitecture];
+@GenerateMocks([FakeRepository])
+void main() {
+  late BuildContext buildcontext;
+  late final MockFakeRepository repository = MockFakeRepository();
+  late final BookProvider bookProvider = BookProvider(repository);
+  final ThemeProvider themeProvider = ThemeProvider();
+
+  Widget createApp() => MaterialApp(
+        home: MaterialApp(
+          home: MultiProvider(
+            providers: [
+              ChangeNotifierProvider<BookProvider>.value(value: bookProvider),
+              ChangeNotifierProvider<ThemeProvider>.value(value: themeProvider),
+            ],
+            builder: (context, child) => Consumer<ThemeProvider>(
+              builder: (context, themeProvider, child) {
+                buildcontext = context;
+                return const HomeScreen();
+              },
+            ),
+          ),
+        ),
+      );
+
+  group('Test SearchResultBuilder:', () {
+    setUp(() {
+      when(repository.fetchNewBookList()).thenAnswer((_) async => expectedNewBookList);
+      when(repository.fetchContinueBookList()).thenAnswer((_) async => expectedContinueBookList);
+      bookProvider.bookSearchResultList = [TestData.cleanCode, TestData.cleanCoder, TestData.cleanArchitecture];
+      bookProvider.authorSearchResultList = [
+        TestData.algorithms,
+        TestData.structureAndInteroretationOfComputerPrograms,
+        TestData.codeComplete
+      ];
+    });
+    testWidgets('when search result list is not empty, buildList() returns a Material Widget', (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(
+          createApp(),
+        );
+        await tester.pump(const Duration(seconds: 2));
+
+        final Widget searchResultList = SearchResultBuilder.buildList(
+          buildcontext,
+          () {},
+        );
+        expect(searchResultList, isNotNull);
+        expect(searchResultList, isInstanceOf<Material>());
+        expect(
+          searchResultList.key,
+          const Key('searchResultKey'),
+        );
+      });
+    });
+
+    testWidgets('when search result list is not empty, buildList() returns a Column as child Widget', (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(
+          createApp(),
+        );
+        await tester.pump(const Duration(seconds: 2));
+
+        final Widget searchResultList = SearchResultBuilder.buildList(
+          buildcontext,
+          () {},
+        );
+        final Widget column = ((searchResultList as Material).child as Padding).child!;
+        expect(
+          column.key,
+          const Key('searchResultDropdownList'),
+        );
+        expect(
+          column,
+          isInstanceOf<Column>(),
+        );
+
+        expect(
+          (column as Column).children.length,
+          8,
+        );
+      });
+    });
+  });
+}

--- a/test/features/book_search/widgets/search_result_list/search_result_builder_test.dart
+++ b/test/features/book_search/widgets/search_result_list/search_result_builder_test.dart
@@ -27,18 +27,16 @@ void main() {
   final ThemeProvider themeProvider = ThemeProvider();
 
   Widget createApp() => MaterialApp(
-        home: MaterialApp(
-          home: MultiProvider(
-            providers: [
-              ChangeNotifierProvider<BookProvider>.value(value: bookProvider),
-              ChangeNotifierProvider<ThemeProvider>.value(value: themeProvider),
-            ],
-            builder: (context, child) => Consumer<ThemeProvider>(
-              builder: (context, themeProvider, child) {
-                buildcontext = context;
-                return const HomeScreen();
-              },
-            ),
+        home: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<BookProvider>.value(value: bookProvider),
+            ChangeNotifierProvider<ThemeProvider>.value(value: themeProvider),
+          ],
+          builder: (context, child) => Consumer<ThemeProvider>(
+            builder: (context, themeProvider, child) {
+              buildcontext = context;
+              return const HomeScreen();
+            },
           ),
         ),
       );

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -1,10 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:provider/provider.dart';
+import 'package:reos_challenge/features/book_search/widgets/widgets.dart';
+import 'package:reos_challenge/features/home/home_screen.dart';
 import 'package:reos_challenge/main.dart';
+import 'package:reos_challenge/shared/models/models.dart';
 import 'package:reos_challenge/shared/providers/providers.dart';
+import 'package:reos_challenge/shared/repositories/fake_repository/fake_repository.dart';
 
+import '../../shared/providers/book_provider_test.mocks.dart';
+import '../../shared/providers/test_data.dart';
+
+@GenerateMocks([FakeRepository])
 void main() {
   Widget createApp() => MaterialApp(
         home: ChangeNotifierProvider<ThemeProvider>(
@@ -54,6 +64,67 @@ void main() {
 
         final Finder navBar = find.byType(NavigationBar);
         expect(navBar, findsOneWidget);
+      });
+    });
+  });
+
+  group('test searchResult display:', () {
+    late final MockFakeRepository repository = MockFakeRepository();
+    late final BookProvider bookProvider = BookProvider(repository);
+    final ThemeProvider themeProvider = ThemeProvider();
+    final List<Book> expectedContinueBookList = [
+      TestData.algorithms,
+      TestData.structureAndInteroretationOfComputerPrograms,
+      TestData.codeComplete
+    ];
+    final List<Book> expectedNewBookList = [TestData.cleanCode, TestData.cleanCoder, TestData.cleanArchitecture];
+    final List<Book> cleanBookList = [TestData.cleanCode, TestData.cleanCoder, TestData.cleanArchitecture];
+
+    Widget createMultiProviderApp() => MaterialApp(
+          home: MultiProvider(
+            providers: [
+              ChangeNotifierProvider<BookProvider>.value(value: bookProvider),
+              ChangeNotifierProvider<ThemeProvider>.value(value: themeProvider),
+            ],
+            builder: (context, child) => Consumer<ThemeProvider>(
+              builder: (context, themeProvider, child) {
+                return const HomeScreen();
+              },
+            ),
+          ),
+        );
+    setUp(() {
+      when(repository.fetchNewBookList()).thenAnswer((_) async => expectedNewBookList);
+      when(repository.fetchContinueBookList()).thenAnswer((_) async => expectedContinueBookList);
+    });
+    testWidgets('When search for searchterm, then Booklist with results is displayed', (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(createMultiProviderApp());
+        await tester.pump(const Duration(seconds: 1));
+        when(repository.searchBooks('clean')).thenAnswer((_) async => cleanBookList);
+        const String searchTerm = 'clean';
+        await bookProvider.onBookSearchCompleted(searchTerm);
+        await tester.pump(const Duration(seconds: 2));
+        final Finder booklist = find.byType(BookList);
+        final Finder bookListItem = find.byType(BookListItem);
+        expect(booklist, findsOneWidget);
+        expect(bookListItem, findsWidgets);
+      });
+    });
+
+    testWidgets('When search with search term that returns no search results, a No-results-screen is shown',
+        (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(createMultiProviderApp());
+        await tester.pump(const Duration(seconds: 1));
+        const String searchTerm = 'kwebdf jkwebf';
+        when(repository.searchBooks('kwebdf jkwebf')).thenAnswer((_) async => []);
+        await bookProvider.onBookSearchCompleted(searchTerm);
+        await tester.pump(const Duration(seconds: 2));
+        final Finder noSearchResultsScreen = find.byType(NoSearchResult);
+        expect(noSearchResultsScreen, findsOneWidget);
+        final Finder bookListItem = find.byType(BookListItem);
+        expect(bookListItem, findsNothing);
       });
     });
   });


### PR DESCRIPTION
This PR:

- splits up buildList() in SearchResultBuilder.dart into smaller sub methods to adhere to the Single Responsibility Principle. 
- Encapsulates the dependency of material_floating_search_bar by limiting its use to a single class (HomseScreen.dart)
- Adds tests to ensure functionality